### PR TITLE
Fix minor typo in methods (MainTapBar->MainTabBar)

### DIFF
--- a/RIBsReactorKit/RIBsReactorKit/Source/Presentation/Scenes/Root/RootInteractor.swift
+++ b/RIBsReactorKit/RIBsReactorKit/Source/Presentation/Scenes/Root/RootInteractor.swift
@@ -12,7 +12,7 @@ import RxSwift
 // MARK: - RootRouting
 
 protocol RootRouting: Routing {
-  func attachMainTapBarRIB()
+  func attachMainTabBarRIB()
   func cleanupViews()
 }
 
@@ -27,7 +27,7 @@ final class RootInteractor: Interactor, RootInteractable {
 
   override func didBecomeActive() {
     super.didBecomeActive()
-    router?.attachMainTapBarRIB()
+    router?.attachMainTabBarRIB()
   }
 
   override func willResignActive() {

--- a/RIBsReactorKit/RIBsReactorKit/Source/Presentation/Scenes/Root/RootRouter.swift
+++ b/RIBsReactorKit/RIBsReactorKit/Source/Presentation/Scenes/Root/RootRouter.swift
@@ -35,12 +35,12 @@ final class RootRouter: LaunchRouter<RootInteractable, RootViewControllable>, Ro
   }
 
   func cleanupViews() {
-    detachMainTapBarRIB()
+    detachMainTabBarRIB()
   }
 }
 
 extension RootRouter {
-  func attachMainTapBarRIB() {
+  func attachMainTabBarRIB() {
     guard mainTabBarRouter == nil else { return }
 
     let router = mainTabBarBuilder.build(withListener: interactor)
@@ -48,7 +48,7 @@ extension RootRouter {
     attachChild(router)
   }
 
-  private func detachMainTapBarRIB() {
+  private func detachMainTabBarRIB() {
     guard let router = mainTabBarRouter else { return }
     detachChild(router)
     mainTabBarRouter = nil


### PR DESCRIPTION
- Fix minor typo in methods
- According to the RIB's name, changed from `MainTapBar` to `MainTabBar`
<img width="467" alt="Screen Shot 2022-01-15 at 11 20 20 PM" src="https://user-images.githubusercontent.com/31857308/149626861-7e93363c-76c0-46d2-a34a-f56df0b7855d.png">